### PR TITLE
Update to monarchmoneycommunity dependency instead of monarchmoney

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -552,20 +552,20 @@ files = [
 ]
 
 [[package]]
-name = "monarchmoney"
-version = "0.1.15"
+name = "monarchmoneycommunity"
+version = "1.1.0"
 description = "Monarch Money API for Python"
 optional = false
 python-versions = "*"
 groups = ["main"]
 files = [
-    {file = "monarchmoney-0.1.15-py2.py3-none-any.whl", hash = "sha256:fab999b88d465f7f14cdc132d1dc3b7f7e2427ef738b9f4da5d5d4fc16effa5f"},
-    {file = "monarchmoney-0.1.15.tar.gz", hash = "sha256:cd11ecdf1b9ba3be9f5a426cb76735fdfc56f750a4e838dc4ced1d9c5c99cc01"},
+    {file = "monarchmoneycommunity-1.1.0-py3-none-any.whl", hash = "sha256:f166f4a7f2d95ec3162bbf26fb221448437c7957eeff5b9eef30614539da0358"},
+    {file = "monarchmoneycommunity-1.1.0.tar.gz", hash = "sha256:015fb2f13f4fa8079484e9000546ee84dfe7202b69194515577a67fd65fde506"},
 ]
 
 [package.dependencies]
 aiohttp = ">=3.8.4"
-gql = ">=3.4"
+gql = ">=4.0"
 oathtool = ">=2.3.1"
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = "^3.12"
-monarchmoney = "^0.1.15"
+monarchmoneycommunity = "^1.1.0"
 rich = ">=10.1.0"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
As the maintainer of monarchmoney (the backing of this library) has seemingly left the project alone, I have moved this to a new pypi package.

At the moment, the current monarchmoney library 0.1.15 is unusable due to the domain changing from `api.monarchmoney.com` to `api.monarch.com` as well as numerous other issues such as auth persistence not hanging, non-mutating methods not working, etc.

This means that the monarchmoney-typed library is now broken which in turn means the integration on Home Assistant is unusable for all users.

Proposal:

- Use the new library I will be maintaining for the foreseeable future `monarchmoneycommunity`
- gql dependency has been updated to 4.0 , the package I have published requires gql > 4.0 due to a breaking change in gql < 4.0.



 